### PR TITLE
Fix logic in binary indicator matrices check

### DIFF
--- a/src/data/multilabel.py
+++ b/src/data/multilabel.py
@@ -12,7 +12,7 @@ def multilabel_sample(y, size=1000, min_count=5, seed=None):
         each label.
     """
     try:
-        if (np.unique(y).astype(int) != np.array([0, 1])).all():
+        if (np.unique(y).astype(int) != np.array([0, 1])).any():
             raise ValueError()
     except (TypeError, ValueError):
         raise ValueError('multilabel_sample only works with binary indicator matrices')


### PR DESCRIPTION
When checking if given y matrix is a binary indicator matrix, any() deviation from the template np.array([0,1]) should be an error